### PR TITLE
Use pyglet resource.path to index sound resource files

### DIFF
--- a/sounds.py
+++ b/sounds.py
@@ -1,5 +1,8 @@
 import pyglet.media
 from os import path
 
-wood_break = pyglet.resource.media(path.join('resources', 'sounds', 'wood_break.wav'), streaming=False)
-water_break = pyglet.resource.media(path.join('resources', 'sounds', 'water_break.wav'), streaming=False)
+pyglet.resource.path = [path.join('resources', 'sounds')]
+pyglet.resource.reindex()
+
+wood_break = pyglet.resource.media('wood_break.wav', streaming=False)
+water_break = pyglet.resource.media('water_break.wav', streaming=False)


### PR DESCRIPTION
It looks like the backslashes created by os.path.join on Windows break loading via pyglet.resource.media (at least on my windows 7 and maybe 8?) -- but are fine when added to pyglet.resource.path.

Can anyone check to make sure this works on other systems?
