### PR TITLE
Use pyglet resource.path to index sound resource files v2

### DIFF
--- a/sounds.py
+++ b/sounds.py
@@ -1,5 +1,7 @@
 import pyglet.media
 from os import path
+pyglet.resource.path = [".","resources/sounds"] #Note: Pyglet uses /'s regardless of OS
+pyglet.resource.reindex()
 
-wood_break = pyglet.resource.media(path.join('resources', 'sounds', 'wood_break.wav'), streaming=False)
-water_break = pyglet.resource.media(path.join('resources', 'sounds', 'water_break.wav'), streaming=False)
+wood_break = pyglet.resource.media("wood_break.wav", streaming=False)
+water_break = pyglet.resource.media("water_break.wav", streaming=False)


### PR DESCRIPTION
Thanks to PR #32 by @tfaris
Pyglet does not like backslashes at all, and wants to be fed /'s only

This works fine on Windows 7 and should be fine on all other OSes.
