### PR TITLE
Optimize world.py using Cython.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,11 @@ For git:
       -nocompression        Disables compression for a smaller save file.
       -gamemode GAMEMODE    Set the Gamemode for player. 0 = Creative, 1 =
                             Survival
+
+## Better performance using Cython
+
+For optimal performance, you can compile the code to C using Cython.
+
+To do so, you have to install Cython (`sudo apt-get install cython` under
+Ubuntu), then run `python setup.py build_ext --inplace --force`.  You will have
+to run this last command each time you update the game.

--- a/main.py
+++ b/main.py
@@ -329,7 +329,6 @@ class Model(World):
             stone_block, stone_block, stone_block, stone_block, stone_block,
         )
 
-
         for x in xrange(-n, n + 1, s):
             for z in xrange(-n, n + 1, s):
 
@@ -683,13 +682,6 @@ class Window(pyglet.window.Window):
         x, y, z = self.collide((x + dx, y + dy, z + dz), 2)
       #  print(str(dy) + ' ' + str(self.dy)) 
         self.player.position = (x, y, z)
-
-    def set_highlighted_block(self, block):
-        self.highlighted_block = block
-        self.block_damage = 0
-        if self.crack:
-            self.crack.delete()
-        self.crack = None
 
     def set_highlighted_block(self, block):
         self.highlighted_block = block

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Distutils import build_ext
+
+from globals import APP_NAME
+
+
+ext_modules = [
+    Extension("world", ["world.py"]),
+]
+
+setup(
+    name=APP_NAME,
+    cmdclass={'build_ext': build_ext},
+    ext_modules=ext_modules
+)

--- a/world.pxd
+++ b/world.pxd
@@ -1,0 +1,97 @@
+import cython
+
+
+@cython.locals(int_f=int)
+cpdef int normalize_float(float f)
+
+
+@cython.locals(x=float, y=float, z=float)
+cpdef tuple normalize(tuple position)
+
+
+@cython.locals(x=int, y=int, z=int)
+cpdef tuple sectorize(tuple position)
+
+
+@cython.locals(spreading_mutations=dict)
+cdef class World(dict):
+    cdef public object batch
+    cdef public object group
+    cdef public dict exposed
+    cdef public dict shown
+    cdef public dict _shown
+    cdef public object sectors
+    cdef public object urgent_queue, lazy_queue
+    cdef public tuple spreading_mutation_classes
+    cdef public double spreading_time
+
+    cpdef object add_block(self, tuple position, object block,
+                           bint sync=?, bint force=?)
+
+    cpdef object remove_block(self, tuple position, bint sync=?, bint sound=?)
+
+    # Generators are not handled by Cython for the moment.
+    # @cython.locals(x=float, y=float, z=float,
+    #                dx=float, dy=float, dz=float)
+    # cpdef object neighbors_iterator(self, tuple position,
+    #                                 tuple relative_neighbors_positions=?)
+
+    @cython.locals(other_position=tuple)
+    cpdef object check_neighbors(self, tuple position)
+
+    @cython.locals(faces=tuple, other_position=tuple)
+    cpdef bint has_neighbors(self, tuple position,
+                             object type=?,bint diagonals=?)
+
+    @cython.locals(other_position=tuple)
+    cpdef bint is_exposed(self, tuple position)
+
+    @cython.locals(m=int, _=int,
+                   x=float, y=float, z=float,
+                   dx=float, dy=float, dz=float,
+                   previous=tuple, key=tuple)
+    cpdef tuple hit_test(self, tuple position, tuple vector,
+                         int max_distance=?)
+
+    cpdef object hide_block(self, tuple position, bint immediate=?)
+
+    cpdef object _hide_block(self, tuple position)
+
+    @cython.locals(position=tuple)
+    cpdef object show_blocks(self)
+
+    @cython.locals(block=object)
+    cpdef object show_block(self, tuple position, bint immediate=?)
+
+    @cython.locals(x=float, y=float, z=float,
+                   index=int, count=int,
+                   vertex_data=cython.list, texture_data=cython.list,
+                   dx=float, dy=float, dz=float,
+                   i=int, j=int)
+    cpdef object _show_block(self, tuple position, object block)
+
+    cpdef object show_sector(self, tuple sector, bint immediate=?)
+
+    @cython.locals(position=tuple)
+    cpdef object _show_sector(self, tuple sector)
+
+    cpdef object hide_sector(self, tuple sector, bint immediate=?)
+
+    @cython.locals(position=tuple)
+    cpdef object _hide_sector(self, tuple sector)
+
+    @cython.locals(before_set=set, after_set=set, pad=int,
+                   dx=int, dy=int, dz=int,
+                   x=int, y=int, z=int,
+                   show=set, hide=set, sector=tuple)
+    cpdef object change_sectors(self, tuple before, tuple after)
+
+    @cython.locals(queue=object)
+    cpdef object dequeue(self)
+
+    cpdef object process_queue(self, double dt)
+
+    cpdef object process_entire_queue(self)
+
+    @cython.locals(position=tuple, block=object)
+    cpdef object content_update(self, double dt)

--- a/world.py
+++ b/world.py
@@ -185,7 +185,7 @@ class World(dict):
         x, y, z = position
         dx, dy, dz = vector
         dx, dy, dz = dx / m, dy / m, dz / m
-        previous = None
+        previous = ()
         for _ in xrange(max_distance * m):
             key = normalize((x, y, z))
             if key != previous and key in self:


### PR DESCRIPTION
Voilà, some static typing.

I chose to do this on world.py because this file contains what consumes most CPU (apart from pyglet).

According to cProfile, during the same in-game time (60 seconds of rendered game), and on the same (large) world, while flying on different directions to force hundreds of sectors to load and unload, and with VISIBLE_SECTORS_RADIUS = 16 and DRAW_DISTANCE = 120.0:

what was taking time:
- pyglet.graphics.Batch.add
- World.add_block during initialization
- World.is_exposed during game

Model.initialize:
- took 17 seconds, with 11.5 seconds taken by World.add_block
- now takes 10 seconds, with 4.7 seconds taken by World.add_block

during game:
- pyglet.graphics.Batch.add took and still takes 23 seconds.
- World.is_exposed took 25 seconds
- World.is_exposed now takes 19 seconds
- Displaying 3D, labels, and sleeping takes 80% of the rest of the time

For now, I think that the main part of the game is enough optimized.  Of course, there is still some little annoying freezes, but they are mainly due to a bad synchronization between the rendering and the queue.  I'll work on that later.

So this is good news, because even when asking hundreds/thousands of chunks updates to the game in one minute, we still have **8.5 % of the time that is spent sleeping**.

When doing nothing, **57 % of the time is spent sleeping**!

So have fun and develop lots of outstanding features, performance will follow :)
