### PR TITLE
Added support for MC 1.5 Texture Pack format 

### DIFF
--- a/world.py
+++ b/world.py
@@ -253,7 +253,7 @@ class World(dict):
 
         # create vertex list
         batch = self.transparency_batch if block.transparent else self.batch
-        self._shown[position] = batch.add(count, GL_QUADS, self.group,
+        self._shown[position] = batch.add(count, GL_QUADS, block.group or self.group,
                                           ('v3f/static', vertex_data),
                                           ('t2f/static', texture_data))
 


### PR DESCRIPTION
Should have nearly identical performance to the single file texture.png format
Still uses old texture.png if a Texture Pack isn't present, unsure if we should phase out the single file format entirely or not.

Should I commit Sphax's textures/blocks folder? Thats the only folder we're scanning so far.
