### PR TITLE
Fixed crash with sound when no device is present

### DIFF
--- a/sounds.py
+++ b/sounds.py
@@ -5,7 +5,6 @@
 
 # Third-party packages
 import pyglet.media
-import pyglet.info
 
 # Modules from this project
 import globals as G


### PR DESCRIPTION
I forgot to enable my sound card, which caused a crash in the game when trying to play sounds. This fix checks if a non-silent audio device is loaded before trying to set it's properties.
