### PR TITLE
Optimize initial sector loading

### DIFF
--- a/globals.py
+++ b/globals.py
@@ -161,7 +161,7 @@ WINDOW_HEIGHT = 480  # Screen height (in pixels)
 MAX_FPS = 60  # Maximum frames per second.
 
 #Maximum time to process the queue
-QUEUE_PROCESS_SPEED = 0.1 / MAX_FPS #Try shrinking this if chunk loading is laggy, higher loads chunks faster
+QUEUE_PROCESS_SPEED = 0.5 / MAX_FPS #Try shrinking this if chunk loading is laggy, higher loads chunks faster
 
 VISIBLE_SECTORS_RADIUS = 8
 DELOAD_SECTORS_RADIUS = 12

--- a/world.py
+++ b/world.py
@@ -34,7 +34,7 @@ class World(dict):
     shown: Dict[iVector, Any]
     _shown: Dict[iVector, Any]
     sectors: DefaultDict[iVector, list]
-    before_set: Set[iVector]
+    sectors_shown: Dict[iVector, bool]
     urgent_queue: Deque[Any]
     lazy_queue: Deque[Any]
     sector_queue: Dict[iVector, bool]
@@ -54,7 +54,7 @@ class World(dict):
         self.shown = {}
         self._shown = {}
         self.sectors = defaultdict(list)
-        self.before_set = set()
+        self.sectors_shown = dict()
         self.urgent_queue = deque()
         self.lazy_queue = deque()
         self.sector_queue = OrderedDict()
@@ -247,8 +247,7 @@ class World(dict):
             del self.sectors[sector]
 
     def change_sectors(self, after: iVector):
-        before_set = self.before_set
-        after_set = set()
+        new_sectors_shown = dict()
         pad = G.VISIBLE_SECTORS_RADIUS
         x, y, z = after
         for distance in range(0, pad + 1):
@@ -259,13 +258,12 @@ class World(dict):
                     for dy in range(-4, 4):
                         if dx ** 2 + dy ** 2 + dz ** 2 > (pad + 1) ** 2:
                             continue
-                        after_set.add((x + dx, y + dy, z + dz))
-        #for sector in (after_set - before_set):
-           # self.show_sector(sector)
+                        new_sectors_shown[(x + dx, y + dy, z + dz)] = True
         #Queue the sectors to be shown, instead of rendering them in real time
-        for sector in (after_set - before_set):
-            self.enqueue_sector(True, sector)
-        self.before_set = after_set
+        for sector in new_sectors_shown.keys():
+            if sector not in self.sectors_shown:
+                self.enqueue_sector(True, sector)
+        self.sectors_shown = new_sectors_shown
 
     def enqueue_sector(self, state: bool, sector: iVector): #State=True to show, False to hide
         self.sector_queue[sector] = state

--- a/world.py
+++ b/world.py
@@ -290,16 +290,14 @@ class World(dict):
 
     def process_queue(self, dt):
         stoptime = time() + G.QUEUE_PROCESS_SPEED
-        while time() < stoptime:
+        while (self.sector_queue or self.sector_packets or self.urgent_queue or self.lazy_queue) and time() < stoptime:
             #Process as much of the queues as we can
             if self.sector_queue:
                 self.dequeue_sector()
-            elif self.sector_packets:
+            if self.sector_packets:
                 self.packetreceiver.dequeue_packet()
-            elif self.urgent_queue or self.lazy_queue:
+            if self.urgent_queue or self.lazy_queue:
                 self.dequeue()
-            else:
-                break
 
     def process_entire_queue(self):
         while self.urgent_queue or self.lazy_queue:


### PR DESCRIPTION
* Client main queue: interweave chunk network requests with rendering, so we don't wait until all chunks we'll ever need are requested, before rendering chunk 2
* Queue up chunks closest-first, it has a much more obvious effect on the player. This was the original intention, but set()'s are unordered, so switch to dict()'s which are basically ordered sets


Fixes #75
