### PR TITLE
Send returning players their saved position on connect, rather than 0,0

### DIFF
--- a/client.py
+++ b/client.py
@@ -149,7 +149,7 @@ class PacketReceiver(Thread):
         elif packetid == 10: # Update Tile Entity
             self.world[struct.unpack("iii", packet[:12])].update_tile_entity(packet[12:])
         elif packetid == 255:  # Spawn Position
-            self.controller.player.position = struct.unpack("iii", packet[:12])
+            self.controller.player.position = struct.unpack("fff", packet[:12])
             packet = packet[12:]
             packet, seed = extract_string_packet(packet)
             self.world.biome_generator = BiomeGenerator(seed)

--- a/savingsystem.py
+++ b/savingsystem.py
@@ -102,7 +102,7 @@ def save_blocks(blocks: custom_types.WorldServer, world: str):
     #blocks and sectors (window.world and window.world.sectors)
     #Saves individual sectors in region files (4x4x4 sectors)
 
-    for secpos in blocks.sectors: #TODO: only save dirty sectors
+    for secpos in blocks.sectors.keys(): #TODO: only save dirty sectors
         if not blocks.sectors[secpos]:
             continue #Skip writing empty sectors
         file = os.path.join(G.game_dir, world, sector_to_filename(secpos))
@@ -182,7 +182,7 @@ def load_region(world: custom_types.WorldServer, world_name: str = "world", regi
                                                 print("load_region: Invalid Block", e)
                                         sectors[(x//SECTOR_SIZE, y//SECTOR_SIZE, z//SECTOR_SIZE)].append(position)
 
-def load_player(player, world: str):
+def load_player(player: custom_types.ServerPlayer, world: str):
     db = connect_db(world)
     cur = db.cursor()
     cur.execute("select * from players where name='%s'" % player.username)

--- a/utils.py
+++ b/utils.py
@@ -3,7 +3,7 @@
 # Python packages
 import os
 import struct
-from typing import Tuple, List
+from typing import Tuple, List, Union
 from ctypes import byref
 
 # Third-party packages
@@ -204,12 +204,10 @@ def normalize(position: fVector) -> fVector:
     return normalize_float(x), normalize_float(y), normalize_float(z)
 
 
-def sectorize(position: iVector) -> iVector:
-    x, y, z = normalize(position)
-    x, y, z = (x // G.SECTOR_SIZE,
-               y // G.SECTOR_SIZE,
-               z // G.SECTOR_SIZE)
-    return x, y, z
+def sectorize(position: Union[iVector, fVector]) -> iVector:
+    return (normalize_float(float(position[0])) // G.SECTOR_SIZE,
+            normalize_float(float(position[1])) // G.SECTOR_SIZE,
+            normalize_float(float(position[2])) // G.SECTOR_SIZE)
 
 
 class TextureGroup(pyglet.graphics.Group):


### PR DESCRIPTION
Looks like there was some confusion between `self.position` and `position`.

Also extracted out send_sector() (really that whole networking layer needs to be split up...), and added some recovery if the player falls through the world (on reconnect, place them on top of where they were)